### PR TITLE
Add -a flag to List command to list all fields

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -85,9 +85,14 @@ The student's phone number, parent's name and parent's phone number are optional
 
 ### Listing all students : `list`
 
-Shows a list of all students in TutorAid in the order that they were added.
+Shows a list of all students in TutorAid in the order that they were added. Use the `-a` flag to display all fields, otherwise fields are hidden by default.
 
-Format: `list`
+Format: `list [-a]`
+
+Examples:
+
+- `list` displays all students in TutorAid while showing only their name and list index
+- `list -a` displays all students in TutorAid while showing all of their data such as their contact number, payment status and so on. 
 
 ### Deleting a student : `delete`
 Deletes the specified student with the given student index from TutorAid.
@@ -229,7 +234,7 @@ Action | Format, Examples
 **Clear** | `clear`
 **Delete student** | `del -s STUDENT_INDEX`<br> e.g., `delete 3`
 **Edit student** | `edit STUDENT_INDEX [sn/STUDENT_NAME] [sp/STUDENT_PHONE] [pn/PARENT_NAME] [pp/PARENT_PHONE]`<br>e.g., `edit 2 pp/91112222` 
-**List** | `list`
+**List** | `list [-a]`<br>e.g., `list`, `list -a` 
 **Help** | `help`
 **Set payment made** | `paid STUDENT_INDEX`<br>e.g., `paid 3`
 **Unset payment made** | `unpaid STUDENT_INDEX`<br>e.g., `unpaid 3`

--- a/src/main/java/tutoraid/logic/commands/ListCommand.java
+++ b/src/main/java/tutoraid/logic/commands/ListCommand.java
@@ -14,10 +14,18 @@ public class ListCommand extends Command {
 
     private final boolean viewAll;
 
+    /**
+     * Default constructor that lists students without showing fields.
+     */
     public ListCommand() {
         this.viewAll = false;
     }
 
+    /**
+     * Constructor for a list command that lists students. Fields are shown if {@code viewAll} is true.
+     *
+     * @param viewAll Whether to show fields
+     */
     public ListCommand(boolean viewAll) {
         this.viewAll = viewAll;
     }

--- a/src/main/java/tutoraid/logic/commands/ListCommand.java
+++ b/src/main/java/tutoraid/logic/commands/ListCommand.java
@@ -10,14 +10,23 @@ import tutoraid.model.Model;
 public class ListCommand extends Command {
 
     public static final String COMMAND_WORD = "list";
-
     public static final String MESSAGE_SUCCESS = "Listed all students";
+
+    private final boolean viewAll;
+
+    public ListCommand() {
+        this.viewAll = false;
+    }
+
+    public ListCommand(boolean viewAll) {
+        this.viewAll = viewAll;
+    }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredStudentList(Model.PREDICATE_SHOW_ALL_STUDENTS);
-        model.viewList();
+        model.viewList(viewAll);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/tutoraid/logic/parser/CliSyntax.java
+++ b/src/main/java/tutoraid/logic/parser/CliSyntax.java
@@ -10,4 +10,5 @@ public class CliSyntax {
     public static final Prefix PREFIX_STUDENT_PHONE = new Prefix("sp/");
     public static final Prefix PREFIX_PARENT_NAME = new Prefix("pn/");
     public static final Prefix PREFIX_PARENT_PHONE = new Prefix("pp/");
+    public static final Prefix PREFIX_LIST_ALL = new Prefix("-a");
 }

--- a/src/main/java/tutoraid/logic/parser/ListCommandParser.java
+++ b/src/main/java/tutoraid/logic/parser/ListCommandParser.java
@@ -4,20 +4,26 @@ import static java.util.Objects.requireNonNull;
 import static tutoraid.logic.parser.CliSyntax.PREFIX_LIST_ALL;
 
 import tutoraid.logic.commands.ListCommand;
-import tutoraid.logic.parser.exceptions.ParseException;
 
 /**
  * Parses input arguments and creates a new ListCommand object
  */
 public class ListCommandParser implements Parser<ListCommand> {
 
-    public ListCommand parse(String args) throws ParseException {
+    /**
+     * Parses the given {@code String} of arguments in the context of ListCommand
+     * and returns a ListCommand object for execution. The command object can instruct
+     * TutorAid to show student fields or hide them when the list of students is displayed.
+     *
+     * @param args Arguments provided by the user command
+     * @return A ListCommand object corresponding to the command
+     */
+    public ListCommand parse(String args) {
         requireNonNull(args);
-        ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_LIST_ALL);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_LIST_ALL);
         if (argMultimap.getValue(PREFIX_LIST_ALL).isEmpty()) {
             return new ListCommand(false);
-        } else {
+        } else { // any unexpected user input is ignored
             return new ListCommand(true);
         }
     }

--- a/src/main/java/tutoraid/logic/parser/ListCommandParser.java
+++ b/src/main/java/tutoraid/logic/parser/ListCommandParser.java
@@ -21,10 +21,10 @@ public class ListCommandParser implements Parser<ListCommand> {
     public ListCommand parse(String args) {
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_LIST_ALL);
-        if (argMultimap.getValue(PREFIX_LIST_ALL).isEmpty()) {
-            return new ListCommand(false);
-        } else { // any unexpected user input is ignored
+        if (argMultimap.getValue(PREFIX_LIST_ALL).isPresent()) {
             return new ListCommand(true);
+        } else { // all unexpected input is ignored
+            return new ListCommand(false);
         }
     }
 }

--- a/src/main/java/tutoraid/logic/parser/ListCommandParser.java
+++ b/src/main/java/tutoraid/logic/parser/ListCommandParser.java
@@ -1,0 +1,24 @@
+package tutoraid.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static tutoraid.logic.parser.CliSyntax.PREFIX_LIST_ALL;
+
+import tutoraid.logic.commands.ListCommand;
+import tutoraid.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new ListCommand object
+ */
+public class ListCommandParser implements Parser<ListCommand> {
+
+    public ListCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_LIST_ALL);
+        if (argMultimap.getValue(PREFIX_LIST_ALL).isEmpty()) {
+            return new ListCommand(false);
+        } else {
+            return new ListCommand(true);
+        }
+    }
+}

--- a/src/main/java/tutoraid/logic/parser/PaidCommandParser.java
+++ b/src/main/java/tutoraid/logic/parser/PaidCommandParser.java
@@ -14,6 +14,7 @@ public class PaidCommandParser implements Parser<PaidCommand> {
     /**
      * Parses the given {@code String} of arguments in the context of PaidCommand
      * and returns a PaidCommand object for execution.
+     *
      * @throws ParseException if the user input does not conform the expected format
      */
     public PaidCommand parse(String args) throws ParseException {

--- a/src/main/java/tutoraid/logic/parser/TutorAidParser.java
+++ b/src/main/java/tutoraid/logic/parser/TutorAidParser.java
@@ -59,6 +59,7 @@ public class TutorAidParser {
             commandWord = matcher.group("commandWord");
             arguments = matcher.group("arguments");
         }
+
         switch (commandWord) {
 
         case AddStudentCommand.COMMAND_WORD:
@@ -74,7 +75,7 @@ public class TutorAidParser {
             return new ClearCommand();
 
         case ListCommand.COMMAND_WORD:
-            return new ListCommand();
+            return new ListCommandParser().parse(arguments);
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/tutoraid/model/Model.java
+++ b/src/main/java/tutoraid/model/Model.java
@@ -84,9 +84,9 @@ public interface Model {
     void viewStudent(Student student);
 
     /**
-     * Views the list of people in the database.
+     * Views the list of students in the database. The viewAll flag determines whether student details should be shown.
      */
-    void viewList();
+    void viewList(boolean viewAll);
 
     /** Returns an unmodifiable view of the filtered student list */
     ObservableList<Student> getFilteredStudentList();

--- a/src/main/java/tutoraid/model/ModelManager.java
+++ b/src/main/java/tutoraid/model/ModelManager.java
@@ -122,8 +122,12 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void viewList() {
-        UiManager.hideViewWindow();
+    public void viewList(boolean viewAll) {
+        if (viewAll) {
+            UiManager.showViewWindow();
+        } else {
+            UiManager.hideViewWindow();
+        }
     }
 
     //=========== Filtered Student List Accessors =============================================================

--- a/src/test/java/tutoraid/logic/commands/AddCommandTest.java
+++ b/src/test/java/tutoraid/logic/commands/AddCommandTest.java
@@ -145,7 +145,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public void viewList() {
+        public void viewList(boolean viewAll) {
             throw new AssertionError("This method should not be called.");
         }
 


### PR DESCRIPTION
List command hides all fields to make it easier for the user to view the index numbers for entry into commands. However, there may be situations where the user wants to scroll through the list of students while looking at their fields. Let's add a flag to the `list` command to allow them to do that. 

`list -a` will continue to list all students but will not hide any fields. 